### PR TITLE
Add base URL for directory to fix status site

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -13,8 +13,7 @@ sites:
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there
-  #cname: demo.upptime.js.org
-  # baseUrl: /your-repo-name
+  baseUrl: /monitoring
   logoUrl: https://raw.githubusercontent.com/upptime/upptime.js.org/master/static/img/icon.svg
   name: EddieHub Upptime
   introTitle: Monitoring of EddieHub apps using Upptime


### PR DESCRIPTION
## Fixes Issue

Status page site doesn't load assets:

<img width="1230" alt="CleanShot 2022-06-30 at 10 15 34@2x" src="https://user-images.githubusercontent.com/2841780/176627850-cb522d72-962e-4cd2-aec6-dc3571db27d0.png">

## Changes proposed

Adds base URL

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.